### PR TITLE
Added $timeout to avoid $digest already in progress errors

### DIFF
--- a/push.js
+++ b/push.js
@@ -8,11 +8,13 @@
 
 angular.module('cordova', [])
 
-  .factory('cordovaReady', function ($rootScope, $q) {
+  .factory('cordovaReady', function ($rootScope, $q, $timeout) {
     var loadingDeferred = $q.defer();
     
     document.addEventListener('deviceready', function () {
-      $rootScope.$apply(loadingDeferred.resolve);
+      $timeout(function() {
+        $rootScope.$apply(loadingDeferred.resolve);
+      });
     });
     
     return function cordovaReady() {


### PR DESCRIPTION
Hi Patrick,

I was getting "$digest already in progress" errors in my ionic project when I tried to use push:

> Error: [$rootScope:inprog] $digest already in progress
> http://errors.angularjs.org/1.2.17/$rootScope/inprog?p0=%24digest
>     at file:///android_asset/www/lib/ionic/js/ionic.bundle.js:7942:12
>     at beginPhase (file:///android_asset/www/lib/ionic/js/ionic.bundle.js:20690:15)
>     at Scope.$apply (file:///android_asset/www/lib/ionic/js/ionic.bundle.js:20479:11)
>     at null.<anonymous> (file:///android_asset/www/lib/push.js:15:18)
>     at Channel.subscribe (file:///android_asset/www/cordova.js:743:11)
>     at HTMLDocument.document.addEventListener (file:///android_asset/www/cordova.js:126:34)
>     at Object.$get (file:///android_asset/www/lib/push.js:14:14)
>     at Object.invoke (file:///android_asset/www/lib/ionic/js/ionic.bundle.js:11763:17)
>     at file:///android_asset/www/lib/ionic/js/ionic.bundle.js:11605:37
>     at getService (file:///android_asset/www/lib/ionic/js/ionic.bundle.js:11726:39) 

I fixed the problem adding $timeout to push.js as suggested in this stackoverflow answer:

http://stackoverflow.com/questions/12729122/prevent-error-digest-already-in-progress-when-calling-scope-apply/18996042#18996042

Best regards
